### PR TITLE
Add basic support for geometry package

### DIFF
--- a/list-of-macros.md
+++ b/list-of-macros.md
@@ -16,6 +16,7 @@ Please note that not everything has to be declared.
 [amsthm](#package-amsthm),
 [babel](#package-babel),
 [biblatex](#package-biblatex),
+[geometry](#package-geometry),
 [glossaries](#package-glossaries),
 [glossaries-extra](#package-glossaries-extra),
 [graphicx](#package-graphicx),
@@ -194,6 +195,16 @@ tests: [tests/test\_packages/test\_biblatex.py](tests/test_packages/test_biblate
 \\parencite,
 \\Parencite,
 \\printbibliography
+
+
+## Package geometry
+
+Source: [yalafi/packages/geometry.py](yalafi/packages/geometry.py),
+tests: [tests/test\_packages/test\_geometry.py](tests/test_packages/test_geometry.py)
+
+**Macros**
+
+\\geometry
 
 
 ## Package glossaries

--- a/tests/test_packages/test_geometry.py
+++ b/tests/test_packages/test_geometry.py
@@ -1,0 +1,25 @@
+
+
+import pytest
+from yalafi import parameters, parser, utils
+
+preamble = '\\usepackage{geometry}\n'
+
+def get_plain(latex):
+    parms = parameters.Parameters()
+    p = parser.Parser(parms)
+    plain, nums = utils.get_txt_pos(p.parse(preamble + latex))
+    assert len(plain) == len(nums)
+    return plain
+
+
+data_test_macros_latex = [
+
+    (r'\geometry{left=40mm, right=40mm, top=40mm, bottom=40mm}', ''),
+
+]
+
+@pytest.mark.parametrize('latex,plain_expected', data_test_macros_latex)
+def test_macros_latex(latex, plain_expected):
+    plain = get_plain(latex)
+    assert plain == plain_expected

--- a/yalafi/packages/__init__.py
+++ b/yalafi/packages/__init__.py
@@ -7,6 +7,7 @@ load_table = {
         'amsthm',
         'babel',
         'biblatex',
+        'geometry',
         'glossaries',
         'glossaries-extra',
         'graphicx',

--- a/yalafi/packages/geometry.py
+++ b/yalafi/packages/geometry.py
@@ -7,14 +7,6 @@ from yalafi.defs import Macro, InitModule
 
 require_packages = []
 
-#
-#   Please note:
-#   - For all undeclared maths macros, which are not blacklisted in
-#     Parameters.math_ignore (yalafi/parameters.py), we assume that
-#     a part of a mathematical term or an operator is left.
-#   - The spacing macros and \notag are imporant for correct parsing
-#     of maths material.
-#
 def init_module(parser, options):
     parms = parser.parms
 

--- a/yalafi/packages/geometry.py
+++ b/yalafi/packages/geometry.py
@@ -1,0 +1,28 @@
+
+#
+#   YaLafi module for LaTeX package geometry
+#
+
+from yalafi.defs import Macro, InitModule
+
+require_packages = []
+
+#
+#   Please note:
+#   - For all undeclared maths macros, which are not blacklisted in
+#     Parameters.math_ignore (yalafi/parameters.py), we assume that
+#     a part of a mathematical term or an operator is left.
+#   - The spacing macros and \notag are imporant for correct parsing
+#     of maths material.
+#
+def init_module(parser, options):
+    parms = parser.parms
+
+    macros_latex = r"""
+
+        \newcommand{\geometry}[1]{}
+
+    """
+
+    return InitModule(macros_latex=macros_latex)
+


### PR DESCRIPTION
I found out about YaLafi yesterday, and it was of great help for checking a large LaTeX document. Many thanks!

Here is my first attempt to contribute, by adding basic support for the `geometry` package: simply ignoring the parameter of the `geometry` command.