### PR TITLE
Add support for xspace

### DIFF
--- a/list-of-macros.md
+++ b/list-of-macros.md
@@ -24,7 +24,8 @@ Please note that not everything has to be declared.
 [listings](#package-listings),
 [pgfplots](#package-pgfplots),
 [tikz](#package-tikz),
-[xcolor](#package-xcolor)
+[xcolor](#package-xcolor),
+[xspace](#package-xspace)
 
 **Document classes**
 
@@ -343,6 +344,16 @@ tests: [tests/test\_packages/test\_xcolor.py](tests/test_packages/test_xcolor.py
 \\definecolor,
 \\fcolorbox,
 \\textcolor
+
+
+## Package xspace
+
+Source: [yalafi/packages/xspace.py](yalafi/packages/xspace.py),
+tests: [tests/test\_packages/test\_xspace.py](tests/test_packages/test_xspace.py)
+
+**Macros**
+
+\\xspace
 
 
 ## Class article

--- a/tests/test_packages/test_xspace.py
+++ b/tests/test_packages/test_xspace.py
@@ -1,0 +1,44 @@
+
+
+import pytest
+from yalafi import parameters, parser, utils
+
+preamble = '\\usepackage{xspace}\n'
+
+def get_plain(latex):
+    parms = parameters.Parameters()
+    p = parser.Parser(parms)
+    plain, nums = utils.get_txt_pos(p.parse(preamble + latex))
+    assert len(plain) == len(nums)
+    return plain
+
+
+footnote_right = r'A\xspace\footnote{This is a footnote.} B'
+footnote_left = r"""A B
+
+
+This is a footnote.
+"""
+
+data_test_macros_latex = [
+
+    (r'A\xspace B', 'A B'),
+    (r'$A\xspace$ B', 'C-C-C B'),
+    (r'A\xspace~B', 'A\N{NO-BREAK SPACE}B'),
+    (r"A\xspace's B", "A's B"),
+    (footnote_right, footnote_left)
+
+]
+
+xspace_excl = ['.', ',', "'", '/', '?', ';', ':', '!', '-', ')']
+
+for i in xspace_excl:
+    left = r'A\xspace' + i + r' B'
+    right = r'A' + i + r' B'
+    data_test_macros_latex.append((left, right))
+
+
+@pytest.mark.parametrize('latex,plain_expected', data_test_macros_latex)
+def test_macros_latex(latex, plain_expected):
+    plain = get_plain(latex)
+    assert plain == plain_expected

--- a/yalafi/packages/__init__.py
+++ b/yalafi/packages/__init__.py
@@ -16,6 +16,7 @@ load_table = {
         'pgfplots',
         'tikz',
         'xcolor',
+        'xspace',
     ],
     '': [
     ],

--- a/yalafi/packages/xspace.py
+++ b/yalafi/packages/xspace.py
@@ -1,0 +1,45 @@
+
+#
+#   YaLafi module for LaTeX package geometry
+#
+
+from yalafi import defs
+from yalafi.defs import Macro, InitModule
+
+require_packages = []
+
+#
+#   Please note:
+#   - For all undeclared maths macros, which are not blacklisted in
+#     Parameters.math_ignore (yalafi/parameters.py), we assume that
+#     a part of a mathematical term or an operator is left.
+#   - The spacing macros and \notag are imporant for correct parsing
+#     of maths material.
+#
+def init_module(parser, options):
+    parms = parser.parms
+
+    macros_latex = ""
+
+    macros_python = [
+
+        Macro(parms, '\\xspace', args='OA', repl=h_xspace),
+
+    ]
+
+    environments = []
+
+    return InitModule(macros_latex=macros_latex, macros_python=macros_python,
+                        environments=environments)
+
+
+xspace_excl = ['.', ',', "'", '/', '?', ';', ':', '!', '~', '-', ')', '$', '\\footnote']
+
+
+def h_xspace(parser, buf, mac, args, pos):
+    if len(args) >= 1:
+        arg = args[1]
+        if hasattr(arg[0], 'txt'):
+            if not arg[0].txt in xspace_excl:
+                arg.insert(0, defs.SpecialToken(pos+1, '\\;'))
+    return arg

--- a/yalafi/packages/xspace.py
+++ b/yalafi/packages/xspace.py
@@ -1,6 +1,6 @@
 
 #
-#   YaLafi module for LaTeX package geometry
+#   YaLafi module for LaTeX package xspace
 #
 
 from yalafi import defs
@@ -8,14 +8,6 @@ from yalafi.defs import Macro, InitModule
 
 require_packages = []
 
-#
-#   Please note:
-#   - For all undeclared maths macros, which are not blacklisted in
-#     Parameters.math_ignore (yalafi/parameters.py), we assume that
-#     a part of a mathematical term or an operator is left.
-#   - The spacing macros and \notag are imporant for correct parsing
-#     of maths material.
-#
 def init_module(parser, options):
     parms = parser.parms
 


### PR DESCRIPTION
The [`xspace` package](https://www.ctan.org/pkg/xspace) provides an `\xspace` command that can be used at the end of a macro. It avoids having to use `\ ` or `{}` after the macro to manually decide if a space is needed after the macro.

Example:
```
\newcommand{\foo}{SuperLongAbbreviation\xspace}
This is \foo and I like \foo.
```
which is nicer than
```
\newcommand{\foo}{SuperLongAbbreviation}
This is \foo{} and I like \foo.
```

This pull request adds support for xspace to YaLafi. It suppresses unwanted “Don't put a space before a full stop” and similar messages from LanguageTool.

I am leaving comments inline, because I am unsure at some places if the code uses the interface to YaLafi correctly.