### PR TITLE
Add KOMA script title commands

### DIFF
--- a/list-of-macros.md
+++ b/list-of-macros.md
@@ -24,6 +24,7 @@ Please note that not everything has to be declared.
 [graphicx](#package-graphicx),
 [hyperref](#package-hyperref),
 [inputenc](#package-inputenc),
+[koma-script](#package-koma-script),
 [listings](#package-listings),
 [mathtools](#package-mathtools),
 [pgfplots](#package-pgfplots),
@@ -366,6 +367,25 @@ tests: [tests/test\_packages/test\_inputenc.py](tests/test_packages/test_inputen
 \\inputencoding
 
 
+## Package koma-script
+
+Source: [yalafi/packages/koma\_script.py](yalafi/packages/koma_script.py),
+tests: [tests/test\_packages/test\_koma\_script.py](tests/test_packages/test_koma_script.py)
+
+This is a helper package only available in YaLafi to implement commands used
+by the KOMA classes
+[scrartcl](#class-scrartcl),
+[scrbook](#class-scrbook) and
+[scrreprt](#class-scrreprt).
+
+**Macros**
+
+\\extratitle,
+\\KOMAoption,
+\\KOMAoptions,
+\\subject,
+\\subtitle
+
 ## Package listings
 
 Source: [yalafi/packages/listings.py](yalafi/packages/listings.py),
@@ -495,8 +515,8 @@ tests: [tests/test\_documentclasses/test\_scrartcl.py](tests/test_documentclasse
 
 **Macros**
 
-\\KOMAoption,
-\\KOMAoptions
+For macros available in all KOMA classes see package
+[koma-script](#package-koma-script).
 
 
 ## Class scrbook
@@ -506,8 +526,8 @@ tests: [tests/test\_documentclasses/test\_scrbook.py](tests/test_documentclasses
 
 **Macros**
 
-\\KOMAoption,
-\\KOMAoptions
+For macros available in all KOMA classes see package
+[koma-script](#package-koma-script).
 
 
 ## Class scrreprt
@@ -517,6 +537,6 @@ tests: [tests/test\_documentclasses/test\_scrreprt.py](tests/test_documentclasse
 
 **Macros**
 
-\\KOMAoption,
-\\KOMAoptions
+For macros available in all KOMA classes see package
+[koma-script](#package-koma-script).
 

--- a/tests/test_documentclasses/test_scrbook.py
+++ b/tests/test_documentclasses/test_scrbook.py
@@ -25,3 +25,9 @@ def test_macros_latex(latex, plain_expected):
     plain = get_plain(latex)
     assert plain == plain_expected
 
+
+def test_package_loaded():
+    parms = parameters.Parameters()
+    p = parser.Parser(parms)
+    p.parse(preamble)
+    assert 'koma-script' in p.packages

--- a/tests/test_documentclasses/test_scrreprt.py
+++ b/tests/test_documentclasses/test_scrreprt.py
@@ -25,3 +25,9 @@ def test_macros_latex(latex, plain_expected):
     plain = get_plain(latex)
     assert plain == plain_expected
 
+
+def test_package_loaded():
+    parms = parameters.Parameters()
+    p = parser.Parser(parms)
+    p.parse(preamble)
+    assert 'koma-script' in p.packages

--- a/tests/test_packages/test_koma_script.py
+++ b/tests/test_packages/test_koma_script.py
@@ -3,7 +3,7 @@
 import pytest
 from yalafi import parameters, parser, utils
 
-preamble = '\\documentclass{scrartcl}\n'
+preamble = '\\usepackage{koma-script}\n'
 
 def get_plain(latex):
     parms = parameters.Parameters()
@@ -17,6 +17,9 @@ data_test_macros_latex = [
 
     (r'A\KOMAoption{opt}B', 'AB'),
     (r'A\KOMAoptions{opts}B', 'AB'),
+    (r'\subject{ho}', 'ho.'),
+    (r'\subtitle{ho}', 'ho.'),
+    (r'\extratitle{ho}', 'ho.'),
 
 ]
 
@@ -25,9 +28,3 @@ def test_macros_latex(latex, plain_expected):
     plain = get_plain(latex)
     assert plain == plain_expected
 
-
-def test_package_loaded():
-    parms = parameters.Parameters()
-    p = parser.Parser(parms)
-    p.parse(preamble)
-    assert 'koma-script' in p.packages

--- a/yalafi/documentclasses/scrartcl.py
+++ b/yalafi/documentclasses/scrartcl.py
@@ -5,19 +5,12 @@
 
 from yalafi.defs import InitModule
 
-require_packages = []
+require_packages = ['koma-script']
 
 def init_module(parser, options, position):
     parms = parser.parms
 
     parser.global_latex_options += options
 
-    macros_latex = r"""
-
-        \newcommand{\KOMAoption}[1]{}
-        \newcommand{\KOMAoptions}[1]{}
-
-    """
-
-    return InitModule(macros_latex=macros_latex)
+    return InitModule()
 

--- a/yalafi/documentclasses/scrbook.py
+++ b/yalafi/documentclasses/scrbook.py
@@ -5,19 +5,12 @@
 
 from yalafi.defs import InitModule
 
-require_packages = []
+require_packages = ['koma-script']
 
 def init_module(parser, options, position):
     parms = parser.parms
 
     parser.global_latex_options += options
 
-    macros_latex = r"""
-
-        \newcommand{\KOMAoption}[1]{}
-        \newcommand{\KOMAoptions}[1]{}
-
-    """
-
-    return InitModule(macros_latex=macros_latex)
+    return InitModule()
 

--- a/yalafi/documentclasses/scrreprt.py
+++ b/yalafi/documentclasses/scrreprt.py
@@ -5,19 +5,12 @@
 
 from yalafi.defs import InitModule
 
-require_packages = []
+require_packages = ['koma-script']
 
 def init_module(parser, options, position):
     parms = parser.parms
 
     parser.global_latex_options += options
 
-    macros_latex = r"""
-
-        \newcommand{\KOMAoption}[1]{}
-        \newcommand{\KOMAoptions}[1]{}
-
-    """
-
-    return InitModule(macros_latex=macros_latex)
+    return InitModule()
 

--- a/yalafi/packages/koma_script.py
+++ b/yalafi/packages/koma_script.py
@@ -1,0 +1,32 @@
+
+#
+#   YaLafi: \documentclass{scrartcl}
+#
+
+from yalafi.defs import InitModule, Macro
+from yalafi import handlers as hs
+
+require_packages = []
+
+
+def init_module(parser, options, position):
+    parms = parser.parms
+
+    parser.global_latex_options += options
+
+    macros_latex = r"""
+
+        \newcommand{\KOMAoption}[1]{}
+        \newcommand{\KOMAoptions}[1]{}
+
+    """
+
+    macros_python = [
+
+        Macro(parms, '\\subtitle', args='*OA', repl=hs.h_heading),
+        Macro(parms, '\\extratitle', args='*OA', repl=hs.h_heading),
+        Macro(parms, '\\subject', args='*OA', repl=hs.h_heading),
+
+    ]
+
+    return InitModule(macros_latex=macros_latex, macros_python=macros_python)


### PR DESCRIPTION
This PR adds support for `\extratitle`, `\subtitle` and `\subject` whenever a KOMA script class is used. To not write the code three times, it is moved to a new package `koma-script` which is not an actual LaTeX package.

There is an extra test checking that the package `koma-script` is loaded successfully. Hence, one could also remove the other tests which are now also in `test/test_packages/test_koma_script`.

Because this is only a helper package I did not add it to the default package list in `yalafi/packages/__init__.py`.

Feel free to make any changes!