### PR TITLE
Add initial minted support

### DIFF
--- a/list-of-macros.md
+++ b/list-of-macros.md
@@ -26,6 +26,7 @@ Please note that not everything has to be declared.
 [inputenc](#package-inputenc),
 [listings](#package-listings),
 [mathtools](#package-mathtools),
+[minted](#package-minted),
 [pgfplots](#package-pgfplots),
 [tikz](#package-tikz),
 [unicode-math](#package-unicode-math),
@@ -397,6 +398,19 @@ tests: [tests/test\_packages/test\_mathtools.py](tests/test_packages/test_mathto
 
 \\mathtoolsset
 
+## Package minted
+
+Source: [yalafi/packages/minted.py](yalafi/packages/minted.py),
+tests: [tests/test\_packages/test\_minted.py](tests/test_packages/test_minted.py)
+
+**Macros**
+
+\\setminted
+\\mintinline
+
+**Environments**
+
+minted
 
 ## Package pgfplots
 

--- a/tests/test_packages/test_minted.py
+++ b/tests/test_packages/test_minted.py
@@ -1,0 +1,39 @@
+
+
+import pytest
+from yalafi import parameters, parser, utils
+
+preamble = '\\usepackage{minted}\n'
+
+def get_plain(latex):
+    parms = parameters.Parameters()
+    p = parser.Parser(parms)
+    plain, nums = utils.get_txt_pos(p.parse(preamble + latex))
+    assert len(plain) == len(nums)
+    return plain
+
+
+data_test_macros_latex = [
+
+    (r'A\setminted{opts}B', 'AB'),
+    (r'A\mintinline{lang}{code}B', 'AB'),
+
+]
+
+@pytest.mark.parametrize('latex,plain_expected', data_test_macros_latex)
+def test_macros_latex(latex, plain_expected):
+    plain = get_plain(latex)
+    assert plain == plain_expected
+
+
+data_test_environments = [
+
+    (r'A\begin{minted}{prolog}[opts]code\end{minted}B', 'A\n\n\nB'),
+
+]
+
+@pytest.mark.parametrize('latex,plain_expected', data_test_environments)
+def test_environments(latex, plain_expected):
+    plain = get_plain(latex)
+    assert plain == plain_expected
+

--- a/yalafi/packages/__init__.py
+++ b/yalafi/packages/__init__.py
@@ -19,6 +19,7 @@ load_table = {
         'inputenc',
         'listings',
         'mathtools',
+        'minted',
         'pgfplots',
         'subfiles',
         'tikz',

--- a/yalafi/packages/minted.py
+++ b/yalafi/packages/minted.py
@@ -1,0 +1,30 @@
+
+#
+#   YaLafi module for LaTeX package minted
+#
+
+from yalafi.defs import InitModule, Environ
+
+require_packages = []
+
+def init_module(parser, options, position):
+    parms = parser.parms
+
+    macros_latex = r"""
+
+        \newcommand{\setminted}[1]{}
+        \newcommand{\mintinline}[2]{}
+
+    """
+
+    macros_python = []
+
+    environments = [
+
+        Environ(parms, 'minted', remove=True),
+
+    ]
+
+    return InitModule(macros_latex=macros_latex, macros_python=macros_python,
+                        environments=environments)
+


### PR DESCRIPTION
I'm using `minted` quite a lot.  This hides the most commonly used macros.  In the future, you'll probably see me contribute the `\newmintedinline` macro with a bit more sophisticated logic behind it.