### PR TITLE
Improve display equation parsing

### DIFF
--- a/list-of-macros.md
+++ b/list-of-macros.md
@@ -165,10 +165,12 @@ tests: [tests/test\_packages/test\_amsmath.py](tests/test_packages/test_amsmath.
 
 align(\*),
 alignat(\*),
+aligned,
 equation(\*),
 flalign(\*),
 gather(\*),
-multiline(\*)
+multline(\*),
+multlined
 
 
 ## Package amsthm

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -186,6 +186,172 @@ def test_9():
     plain, pos = utils.get_txt_pos(toks)
     assert plain_9 == plain
 
+
+latex_11 = r"""
+\usepackage{amsmath}
+A
+\begin{multline}
+    a = b \\
+    - c.
+\end{multline}
+B
+"""
+plain_11 = r"""
+A
+  V-V-V
+   minus W-W-W.
+B
+"""
+def test_11():
+    p = parser.Parser(parameters.Parameters())
+    toks = p.parse(latex_11)
+    plain, pos = utils.get_txt_pos(toks)
+    assert plain_11 == plain
+
+
+latex_12 = r"""
+\usepackage{amsmath}
+A
+\begin{multline}
+    a = b \\
+    c.
+\end{multline}
+B
+"""
+plain_12 = r"""
+A
+  V-V-V
+  V-V-V.
+B
+"""
+def test_12():
+    p = parser.Parser(parameters.Parameters())
+    toks = p.parse(latex_12)
+    plain, pos = utils.get_txt_pos(toks)
+    assert plain_12 == plain
+
+
+latex_13 = r"""
+\usepackage{amsmath}
+A
+\begin{align}
+    a &=
+    \begin{multlined}[t]
+    b \\
+    + c.
+    \end{multlined}
+\end{align}
+B
+"""
+plain_13 = r"""
+A
+  V-V-V  equal   W-W-W
+   plus X-X-X.
+B
+"""
+def test_13():
+    p = parser.Parser(parameters.Parameters())
+    toks = p.parse(latex_13)
+    plain, pos = utils.get_txt_pos(toks)
+    assert plain_13 == plain
+
+
+latex_14 = r"""
+\usepackage{amsmath}
+A
+\begin{align}
+    a &=
+    \begin{aligned}[t]
+    \end{aligned}
+\end{align}
+B
+"""
+plain_14 = r"""
+A
+  V-V-V  equal   
+B
+"""
+def test_14():
+    p = parser.Parser(parameters.Parameters())
+    toks = p.parse(latex_14)
+    plain, pos = utils.get_txt_pos(toks)
+    assert plain_14 == plain
+
+
+latex_15 = r"""
+\usepackage{amsmath}
+A
+\begin{align}
+    a &=
+    \begin{aligned}[t]
+    & c \\
+    &+ d.
+    \end{aligned}
+\end{align}
+B
+"""
+plain_15 = r"""
+A
+  V-V-V  equal    W-W-W
+    plus X-X-X.
+B
+"""
+def test_15():
+    p = parser.Parser(parameters.Parameters())
+    toks = p.parse(latex_15)
+    plain, pos = utils.get_txt_pos(toks)
+    assert plain_15 == plain
+
+
+latex_16 = r"""
+\usepackage{amsmath}
+A
+\begin{equation}
+    a
+    = \begin{aligned}[t]
+    & c \\
+    &+ d.
+    \end{aligned}
+\end{equation}
+B
+"""
+plain_16 = r"""
+A
+  X-X-X   V-V-V
+    plus W-W-W.
+B
+"""
+def test_16():
+    p = parser.Parser(parameters.Parameters())
+    toks = p.parse(latex_16)
+    plain, pos = utils.get_txt_pos(toks)
+    assert plain_16 == plain
+
+
+latex_17 = r"""
+\usepackage{amsmath}
+A
+\begin{equation}
+    a=\begin{cases}
+    0&  \text{if something},\\
+    1&  \text{else}.
+\end{cases}
+\end{equation}
+B
+"""
+plain_17 = r"""
+A
+  V-V-V if something,
+  W-W-W else.
+B
+"""
+def test_17():
+    p = parser.Parser(parameters.Parameters())
+    toks = p.parse(latex_17)
+    plain, pos = utils.get_txt_pos(toks)
+    assert plain_17 == plain
+
+
 #   simplified equation parsing
 #
 latex_10 = r"""

--- a/yalafi/defs.py
+++ b/yalafi/defs.py
@@ -395,8 +395,14 @@ class Environ(Expandable):
 
 class EquEnv(Environ):
     def __init__(self, parms, name, args='', repl='', defaults=None,
-                       remove=False):
+                       remove=False, no_first_section=False):
         if defaults is None:
             defaults = []
         super().__init__(parms, name, args, repl, defaults,
                          add_pars=False, remove=remove)
+        self.no_first_section = no_first_section
+        """
+        Boolean indicating that an equation environment has no sections
+        separated by ``&``.  Used for ``multline`` and ``multlined`` to
+        correctly replace the first math operator in a line.
+        """

--- a/yalafi/mathparser.py
+++ b/yalafi/mathparser.py
@@ -150,6 +150,8 @@ class MathParser:
                 out.append(defs.SpaceToken(out[-1].pos, '\n  ', pos_fix=True))
                 self.parser.parse_newline_option(buf, False)
                 first_section = True
+                if env.no_first_section:
+                    first_section = False
             else:
                 break
             if buf.cur():
@@ -273,6 +275,10 @@ class MathParser:
                             or tok.txt in parms.math_ignore):
                     t.insert(0, defs.MathElemToken(tok.pos, tok.txt))
                 buf.back(t)
+                continue
+            elif type(tok) is defs.MathBeginToken:
+                # Correctly parse `multlined` and `aligned`
+                out += self.expand_display_math(buf, tok, tok.environ)
                 continue
             elif type(tok) in (defs.MathElemToken, defs.MathOperToken,
                                             defs.MathSpaceToken):

--- a/yalafi/packages/amsmath.py
+++ b/yalafi/packages/amsmath.py
@@ -53,8 +53,11 @@ def init_module(parser, options, position):
         EquEnv(parms, 'flalign*'),
         EquEnv(parms, 'gather'),
         EquEnv(parms, 'gather*'),
-        EquEnv(parms, 'multiline'),
-        EquEnv(parms, 'multiline*'),
+        EquEnv(parms, 'multline', no_first_section=True),
+        EquEnv(parms, 'multline*', no_first_section=True),
+        EquEnv(parms, 'multlined', args='O', no_first_section=True),
+        # Add aligned such that its begin cycles the replacements:
+        EquEnv(parms, 'aligned', args='O'),
 
     ]
 


### PR DESCRIPTION
Mainly fixes #197. We add a new attribute `no_first_section` to `EquEnv` so that the first math operator in a line is replaced (not only the first one after a `&`).

- Correct spelling of `multline` environment.
- Reduce false positives when `multlined` or `aligned` appear after an equality sign.
- Add `multlined` and `aligned` environments.